### PR TITLE
Implement concatWith

### DIFF
--- a/src/basis/__string.sml
+++ b/src/basis/__string.sml
@@ -136,6 +136,11 @@ structure String : STRING =
 
     (* basis concat is aka old style implode *)
 
+    fun concatWith _ [] = ""
+      | concatWith _ [s] = s
+      | concatWith sep (s :: ss) =
+	concat (rev (foldl (fn (s, ss) => s :: sep :: ss) [s] ss))
+
     fun compare (x:string,y) = 
       if x<y then LESS else if x>y then GREATER else EQUAL
 

--- a/src/basis/string.sml
+++ b/src/basis/string.sml
@@ -81,6 +81,7 @@ signature STRING =
     val sub : (string * int) -> char
     val extract : (string * int * int option) -> string 
     val concat    : string list -> string
+    val concatWith : string -> string list -> string
     val ^         : string * string -> string
     val implode   : char list -> string
     val explode : string -> char list


### PR DESCRIPTION
Fixes issue #8.
- basis/string.sml (concatWith): New.
- basis/__string.sml (concatWith): Implement it. Perhaps a bit too naive.
