### PR TITLE
Implement Posix.ProcEnv.getpid

### DIFF
--- a/src/rts/src/OS/Unix/unix.c
+++ b/src/rts/src/OS/Unix/unix.c
@@ -1528,6 +1528,12 @@ static mlval unix_kill(mlval arg)
   return MLUNIT;
 }
 
+static mlval unix_getpid(mlval arg)
+{
+  pid_t pid = getpid ();
+  return MLINT(pid);
+}
+
 /*
  * OS.Process.terminate: Word32.word -> 'a
  */
@@ -1693,6 +1699,7 @@ extern void unix_init(void)
   env_function("system os unix getpwnam", unix_getpwnam);
   env_function("system os unix password_file", unix_password_file);
   env_function("system os unix kill", unix_kill);
+  env_function("system os unix getpid", unix_getpid);
 
   env_function("system os unix pipe", unix_pipe);
 

--- a/src/unix/_unixos.sml
+++ b/src/unix/_unixos.sml
@@ -344,6 +344,18 @@ struct
     val close : FileSys.file_desc -> unit = MLWorks.Internal.IO.close
   end
 
+  structure Process = struct
+      datatype pid = PID of int
+      fun pidToWord (PID id) = SysWord.fromInt id
+      fun wordToPid w = PID (SysWord.toInt w)
+    end
+
+  structure ProcEnv = struct
+      type pid = Process.pid
+      val getpid' : unit -> int = env "system os unix getpid"
+      fun getpid () = Process.PID (getpid' ())
+    end
+
   val can_input : FileSys.file_desc -> int = MLWorks.Internal.IO.can_input
 
   val set_block_mode : FileSys.file_desc * bool -> unit = 

--- a/src/unix/platform_specific_exports.sml
+++ b/src/unix/platform_specific_exports.sml
@@ -37,6 +37,8 @@
 
 require "unix";
 require "__unix";
+require "__unixos";
 
 signature UNIX = UNIX;
 structure Unix = Unix;
+structure Posix = UnixOS_;

--- a/src/unix/unixos.sml
+++ b/src/unix/unixos.sml
@@ -280,11 +280,20 @@ signature UNIXOS =
 
     end
 
-
     structure IO : sig
       val close : FileSys.file_desc -> unit
     end
 
+    structure Process : sig
+      eqtype pid
+      val pidToWord : pid -> SysWord.word
+      val wordToPid : SysWord.word -> pid
+    end
+
+    structure ProcEnv : sig
+      eqtype pid
+      val getpid : unit -> pid
+    end
 
     val can_input       : FileSys.file_desc -> int
     val set_block_mode  : FileSys.file_desc * bool -> unit


### PR DESCRIPTION
Fixes issue #9.
- unix/unixos.sml, unix/_unixos.sml: Add structures Process and
  ProcEnv which have getpid but miss everything else needed to
  be standard compatible.
- unix/platform_specific_exports.sml: Make Posix an alias for UnixOS_.
  Of course many things are missing or wrong, but Posix.ProcEnv.getpid
  at least works.
- rts/src/OS/Unix/unix.c (unix_getpid): New.
