### PR TITLE
Change type of the inputLine function in TEXT_IO and TEXT_STREAM_IO

### DIFF
--- a/src/basis/__text_stream_io.sml
+++ b/src/basis/__text_stream_io.sml
@@ -70,7 +70,7 @@ require "__char_array";
 require "__char";
 require "__substring";
 require "__text_prim_io";
-
+require "__list";
 
 structure TextStreamIO: TEXT_STREAM_IO =
 struct
@@ -82,27 +82,17 @@ struct
   in
 
     fun inputLine (f: S.instream) =
-       let
-           (* the following function returns a triple:
-               (l,b,g), where l is a list of characters
-                              b is value of proposition "last char is newline"
-                              g is the input stream at the end
-            *)
-
-         fun loop(i,g) = case S.input1 g of
-            SOME(c, g') =>
-              if c = Char.chr 10 then ([c],true,g') 
-              else let val (l,b,g'')= loop(i+1,g') in (c::l,b,g'') end
-          | NONE => ([],false,g)
-
-         val (l,lastCharNewline,f') = loop(0,f)
-       in
-         (if l<>[] andalso (not lastCharNewline)
-            then implode (l@[#"\n"])
-          else implode l,
-          f')
-       end
-         
+      let
+	  fun some (acc, g) = SOME (implode (List.revAppend (acc, [#"\n"])), g)
+	  fun loop (g, acc) =
+	    case S.input1 g of
+		SOME(c, g') =>
+		if c = Char.chr 10 then some (acc, g')
+		else loop (g', c :: acc)
+              | NONE => case acc of
+			    [] => NONE
+			  | _ => some (acc, g)
+      in loop (f, []) end
 
      fun outputSubstr(f:S.outstream, ss:Substring.substring) =
        S.output(f,Substring.string ss)

--- a/src/basis/_text_io.sml
+++ b/src/basis/_text_io.sml
@@ -153,16 +153,13 @@ functor TextIO(include sig
            (TextIO'.StreamIO.mkInstream
              (OSPrimIO.openString s,""))
 
-     
      fun inputLine (f: TextIO'.instream) =
-       let
-         val g0 = TextIO'.getInstream f
-         val (s,gn) = TextStreamIO.inputLine g0
-         val _ = TextIO'.setInstream(f,gn)
+       let val g0 = TextIO'.getInstream f
        in
-         s
+	   case TextStreamIO.inputLine g0 of
+	       NONE => NONE
+	     | SOME (line, g1) => (TextIO'.setInstream(f, g1); SOME line)
        end
-         
 
      fun outputSubstr(f:TextIO'.outstream, ss:Substring.substring) =
        TextIO'.output(f,Substring.string ss)

--- a/src/basis/text_io.sml
+++ b/src/basis/text_io.sml
@@ -127,7 +127,7 @@ signature TEXT_IO =
     val setOutstream : (outstream * StreamIO.outstream) -> unit
 
 
-    val inputLine : instream -> string
+    val inputLine : instream -> string option
 
     val outputSubstr : (outstream * Substring.substring) -> unit
 

--- a/src/basis/text_stream_io.sml
+++ b/src/basis/text_stream_io.sml
@@ -59,7 +59,7 @@ signature TEXT_STREAM_IO =
 
     include STREAM_IO
 
-    val inputLine : instream -> (string * instream)
+    val inputLine : instream -> (string * instream) option
 
     val outputSubstr : (outstream * Substring.substring) -> unit
 

--- a/src/debugger/_ml_debugger.sml
+++ b/src/debugger/_ml_debugger.sml
@@ -2426,7 +2426,7 @@ functor Ml_Debugger(
                             (do_quit(); raise Exit)
                           else ()
 
-                        val line = TextIO.inputLine TextIO.stdIn
+                        val line = getOpt (TextIO.inputLine TextIO.stdIn, "")
                       in
                         parse_command line
                       end

--- a/src/interpreter/_inspector.sml
+++ b/src/interpreter/_inspector.sml
@@ -218,7 +218,7 @@ functor Inspector (
             val _ = print "Inspector> "
             val _ = TextIO.flushOut TextIO.stdOut;
           in
-            case rev (explode (TextIO.inputLine(TextIO.stdIn))) of
+            case rev (explode (getOpt (TextIO.inputLine(TextIO.stdIn), ""))) of
               [] => ()
             | (_::tagl) =>
                 let

--- a/src/interpreter/_save_image.sml
+++ b/src/interpreter/_save_image.sml
@@ -387,12 +387,9 @@ struct
                 | parse1 (a::rest,acc) = parse1 (rest,a::acc)
 
               fun loop acc =
-                let
-                  val line = TextIO.inputLine instream
-                in
-                  if line = "" then rev acc
-                  else loop (parse1 (explode line,[])::acc)
-                end
+		case TextIO.inputLine instream of
+		    NONE => rev acc
+		  | SOME line => loop (parse1 (explode line,[])::acc)
 
               val items = loop []
                 handle

--- a/src/interpreter/_tty_listener.sml
+++ b/src/interpreter/_tty_listener.sml
@@ -373,7 +373,7 @@ struct
         let
 	  val _ = output_fn(do_prompt ("MLWorks", state))
 	  (* val _ = MLWorks.IO.clear_eof MLWorks.IO.std_in *)
-          val line = TextIO.inputLine TextIO.stdIn
+          val line = getOpt (TextIO.inputLine TextIO.stdIn, "")
 		     handle IO.Io _ => ""
           val new_state =
 	    (case #3 (ShellTypes.with_toplevel_name title

--- a/src/main/_sectioned_file.sml
+++ b/src/main/_sectioned_file.sml
@@ -109,11 +109,11 @@ struct
 
   fun readSectionedFile filename =
         let val instream = TextIO.openIn filename
-            fun get_line() = 
-                  let val line = TextIO.inputLine instream
-                   in if line = ""
-                      then raise (InvalidSectionedFile "Premature EOF")
-                      else line end 
+
+            fun get_line () =
+              case TextIO.inputLine instream of
+		  SOME line => line
+		| NONE => raise (InvalidSectionedFile "Premature EOF")
 
             fun read_section () =
                   let val header = get_line()
@@ -139,8 +139,10 @@ struct
                       val (line, _) = Substring.splitr Char.isSpace line
                       val item = 
                             getOpt(String.fromString(Substring.string line),"")
-                   in item :: (read_items (n - 1)) end
-            val stamp = getOpt(String.fromString(TextIO.inputLine instream),"")
+                  in item :: (read_items (n - 1)) end
+
+	    val firstline = getOpt(TextIO.inputLine instream, "")
+            val stamp = getOpt(String.fromString(firstline), "")
             val (section, _) = read_section()
          in (TextIO.closeIn instream; (stamp, section))
             handle exn => (TextIO.closeIn instream; raise exn)


### PR DESCRIPTION
To be compatible with the standard, inputLine should return a  string option.
According to http://sml-family.org/Basis/history.html
this was changed on September 15, 2003.
