### PR TITLE
x.c:widget_values_get(): use a reference into a XtArgVal array.

### DIFF
--- a/src/motif/_xm.sml
+++ b/src/motif/_xm.sml
@@ -1011,7 +1011,7 @@ functor Xm (structure List: LIST) : XM =
           | pairToRep (MESSAGE_WINDOW, WIDGET w) =
 	      ("messageWindow", ARGUNBOXED (ref (cast w)))
           | pairToRep (WIDTH, INT i) =
-	      ("width", ARGSHORT (ref i))
+	      ("width", ARGSHORT (ref i ))
           | pairToRep (HEIGHT, INT i) =
 	      ("height", ARGSHORT (ref i))
           | pairToRep (X, INT i) =


### PR DESCRIPTION
Its been forever since I did any C, but I believe this should fix the segfault on window close,
according to man XtGetValues,
> The value field of a passed argument list should contain the address into which to store the corresponding resource value.

And got rid of a malloc while there as well...

[edit 2]
 The game of whack a mole continues, It appears the main issue with the original code was that
 it would copy a 16 bit short into a 32 bit XtArgVal, leaving 16 bits uninitialized, then reading the 32 bit value later would make things unhappy...

I renamed args_to_pairs, since the 2 no longer expect the same kind of Arg,
the latter expects args filled with pointers, while the former expects args filled with values.
and widget_values_get is the only caller of xt_args_to_pairs.

sorry for the churn.
