### PR TITLE
Update batch.mlp size headers after the removal of main/*license.sml

### DIFF
--- a/src/batch.mlp
+++ b/src/batch.mlp
@@ -1,9 +1,9 @@
 MLWorks 2.0
-batch.mlp 661 7
+batch.mlp 658 7
   AboutInfo 2 2
     Version 0 0
     Description 0 0
-  Files 407 0
+  Files 404 0
     utils/mlworks_exit.sml
     dependency/__ordered_set.sml
     dependency/__module_name.sml


### PR DESCRIPTION
Loading batch.mlp would cause a "Missing section size for section" error when bootstrapping